### PR TITLE
Extending DevCommand metadata for allowing untyped pushing of DevCommand to Commands

### DIFF
--- a/rfcs/77-dev-tools-abstraction.md
+++ b/rfcs/77-dev-tools-abstraction.md
@@ -503,7 +503,7 @@ And also Reflect trait allows you to get fields by their name for Strut and Enum
     ...
 ```
 
-With the ability to set separate values for DevCommand and ModalDevTool we can build a simple CLI perserver with minimal code
+With the ability to set separate values for DevCommand and ModalDevTool we can build a simple CLI parser with minimal code
 
 ```rust
 fn parse_reflect_from_cli(&self, words: Vec<&str>, target: &mut Box<dyn Reflect>) -> Result<(), DevToolParseError> {

--- a/rfcs/77-dev-tools-abstraction.md
+++ b/rfcs/77-dev-tools-abstraction.md
@@ -104,22 +104,24 @@ In order to facilitate the creation of toolboxes, Bevy provides the `ModalDevToo
 /// and they can be enabled, disabled and reconfigured at runtime.
 /// 
 /// The documentation on this struct is reflected, and can be read by toolboxes to provide help text to users.
-trait ModalDevTool: Resource + Reflect + FromReflect + FromStr<Err=DevToolParseError> + Debug {
+pub trait ModalDevTool: Resource + Reflect + FromReflect + GetTypeRegistration + FromStr<Err=DevToolParseError> + Debug {
     /// The name of this tool, as might be supplied by a command line interface.
     fn name() -> &'static str {
-        Self::type_name().to_snake_case()
+        Self::get_type_registration().type_info().type_path_table().short_path()
     }
     
-    fn short_description() -> Option<&'static str>;
+    fn short_description() -> Option<&'static str> {
+        None
+    }
 
     /// The metadata for this modal dev tool.
     fn metadata() -> DevToolMetaData {
         DevToolMetaData {
             name: Self::name(),
-            type_id: Self::type_id(),
-            type_info: Self::type_info(),
+            type_id: Self::get_type_registration().type_id(),
+            type_info: Self::get_type_registration().type_info(),
             // A function pointer, based on the std::str::from_str method
-            from_str_fn: <Self as FromStr>::from_str,
+            from_str_fn: |s| <Self as FromStr>::from_str(s).map(|x| Box::new(x) as Box<dyn Reflect>),
             short_description: Self::short_description()
         }
     }
@@ -148,6 +150,14 @@ trait ModalDevTool: Resource + Reflect + FromReflect + FromStr<Err=DevToolParseE
             self.enable();
         }
     }
+}
+
+pub struct DevToolMetaData {
+    pub name: &'static str,
+    pub type_id: TypeId,
+    pub type_info: &'static TypeInfo,
+    pub from_str_fn: fn(&str) -> Result<Box<dyn Reflect>, DevToolParseError>,
+    pub short_description: Option<&'static str>
 }
 ```
 
@@ -231,22 +241,41 @@ To model this, we leverage Bevy's existing `Command` trait, which exists to perf
 /// to construct an instance of the type that implements this type, and then send it as a `Command` to execute it.
 /// 
 /// The documentation on this struct is reflected, and can be read by toolboxes to provide help text to users.
-trait DevCommand: Command + Reflect + FromReflect + FromStr<Err=DevToolParseError> + Debug + 'static {
+pub trait DevCommand: bevy::ecs::world::Command + Reflect + FromReflect + GetTypeRegistration + Default + FromStr<Err=DevToolParseError> + Debug + 'static {
     /// The name of this tool, as might be supplied by a command line interface.
     fn name() -> &'static str {
-        Self::type_name().to_snake_case()
+        Self::get_type_registration().type_info().type_path_table().short_path()
     }
+
+    fn short_description() -> Option<&'static str>;
 
     /// The metadata for this dev command.
     fn metadata() -> DevCommandMetadata {
         DevCommandMetadata {
-            name: self.name(),
-            type_id: Self::type_id(),
-            type_info: Self::type_info(),
+            name: Self::name(),
+            type_id: Self::get_type_registration().type_id(),
+            type_info: Self::get_type_registration().type_info(),
             // A function pointer, based on the std::str::from_str method
-            from_str_fn: <Self as FromStr>::from_str
+            from_str_fn: |s| <Self as FromStr>::from_str(s).map(|x| Box::new(x) as Box<dyn Reflect>),
+            //
+            create_default_fn: || Box::new(Self::default()),
+            // A function pointer that adds the DevCommand to the provided Commands 
+            // This is needed because we can'n add Box<dyn Command> to Commands withh commmands.add method
+            // So we need to do it in typed way
+            add_self_to_commands_fn: |commands, reflected_self| commands.add(<Self as FromReflect>::from_reflect(reflected_self).unwrap()),
+            short_description: Self::short_description()
         }
     }
+}
+
+pub struct DevCommandMetadata {
+    pub name: &'static str,
+    pub type_id: TypeId,
+    pub type_info: &'static TypeInfo,
+    pub from_str_fn: fn(&str) -> Result<Box<dyn Reflect>, DevToolParseError>,
+    pub create_default_fn: fn() -> Box<dyn Reflect>,
+    pub add_self_to_commands_fn: fn(commands: &mut Commands, reflected_self: &dyn Reflect),
+    pub short_description: Option<&'static str>
 }
 ```
 

--- a/rfcs/77-dev-tools-abstraction.md
+++ b/rfcs/77-dev-tools-abstraction.md
@@ -151,14 +151,6 @@ pub trait ModalDevTool: Resource + Reflect + FromReflect + GetTypeRegistration +
         }
     }
 }
-
-pub struct DevToolMetaData {
-    pub name: &'static str,
-    pub type_id: TypeId,
-    pub type_info: &'static TypeInfo,
-    pub from_str_fn: fn(&str) -> Result<Box<dyn Reflect>, DevToolParseError>,
-    pub short_description: Option<&'static str>
-}
 ```
 
 Modal dev tools are registered via `app.init_modal_dev_tool::<D>()` (to use default config based on the `FromWorld` implementation) or via `app.insert_modal_dev_tool(config: D)`.
@@ -266,16 +258,6 @@ pub trait DevCommand: bevy::ecs::world::Command + Reflect + FromReflect + GetTyp
             short_description: Self::short_description()
         }
     }
-}
-
-pub struct DevCommandMetadata {
-    pub name: &'static str,
-    pub type_id: TypeId,
-    pub type_info: &'static TypeInfo,
-    pub from_str_fn: fn(&str) -> Result<Box<dyn Reflect>, DevToolParseError>,
-    pub create_default_fn: fn() -> Box<dyn Reflect>,
-    pub add_self_to_commands_fn: fn(commands: &mut Commands, reflected_self: &dyn Reflect),
-    pub short_description: Option<&'static str>
 }
 ```
 
@@ -615,10 +597,12 @@ We also need access to one other critical piece of information: a function point
 As a result our `DevToolMetadata` looks like:
 
 ```rust
-struct DevToolMetadata {
-   name: String,
-   type_info: TypeInfo,
-   from_str: StringConstructorFn,
+struct DevToolMetaData {
+    name: &'static str,
+    type_id: TypeId,
+    type_info: &'static TypeInfo,
+    from_str_fn: fn(&str) -> Result<Box<dyn Reflect>, DevToolParseError>,
+    short_description: Option<&'static str>
 }
 ```
 

--- a/rfcs/77-dev-tools-abstraction.md
+++ b/rfcs/77-dev-tools-abstraction.md
@@ -537,7 +537,7 @@ fn parse_reflect_from_cli(&self, words: Vec<&str>, target: &mut Box<dyn Reflect>
                     return Err(DevToolParseError::InvalidToolData);
                 };
     
-                // Convert the word into the field's value with refistered applyer (FromStr implementations)
+                // Convert the word into the field's value with registered applyer (FromStr implementations)
                 let mut ok = false;
                 for applyer in self.apply_from_string.iter() {
                     if applyer(field, &word) {
@@ -556,7 +556,7 @@ fn parse_reflect_from_cli(&self, words: Vec<&str>, target: &mut Box<dyn Reflect>
                     return Err(DevToolParseError::InvalidToolData);
                 };
     
-                // Convert the word into the field's value with refistered applyer (FromStr implementations)
+                // Convert the word into the field's value with registered applyer (FromStr implementations)
                 let mut ok = false;
                 for applyer in self.apply_from_string.iter() {
                     if applyer(field, &word) {

--- a/rfcs/77-dev-tools-abstraction.md
+++ b/rfcs/77-dev-tools-abstraction.md
@@ -452,7 +452,7 @@ Another valuable approach we can undertake involves constructing a comprehensive
 
 ```bash
 command_name arg0 arg1 arg2  --named-arg4 value --named-arg5 value
-| command     | positional args | named args |
+| command  | positional args|         named args                  |
 ```
 
 * `command_name` represents the name of the command being executed.

--- a/rfcs/77-dev-tools-abstraction.md
+++ b/rfcs/77-dev-tools-abstraction.md
@@ -577,7 +577,7 @@ fn parse_reflect_from_cli(&self, words: Vec<&str>, target: &mut Box<dyn Reflect>
     Ok(())
 }
 
-struct CLIDebom {
+struct CLIDemo {
     /// Functions to convert strings into field values and set field by converted value
     /// Return true if successful, false if not
     pub apply_from_string: Vec<fn(&mut dyn Reflect, &str) -> bool>,

--- a/rfcs/77-dev-tools-abstraction.md
+++ b/rfcs/77-dev-tools-abstraction.md
@@ -260,7 +260,7 @@ pub trait DevCommand: bevy::ecs::world::Command + Reflect + FromReflect + GetTyp
             //
             create_default_fn: || Box::new(Self::default()),
             // A function pointer that adds the DevCommand to the provided Commands 
-            // This is needed because we can'n add Box<dyn Command> to Commands withh commmands.add method
+            // This is needed because we can't add Box<dyn Command> to Commands withh commmands.add method
             // So we need to do it in typed way
             add_self_to_commands_fn: |commands, reflected_self| commands.add(<Self as FromReflect>::from_reflect(reflected_self).unwrap()),
             short_description: Self::short_description()


### PR DESCRIPTION
And fixing geting type info in traits

[RENDERED](https://github.com/rewin123/rfcs/blob/rewin123-some_extends/rfcs/77-dev-tools-abstraction.md)